### PR TITLE
Ruby packages dependencies added

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 pkg-query is a simple web scraping tool that allows you to compare the version of a package across some Linux distributions.
 
+## Dependencies
+
+Another ruby packages are needed in order to run the script. You can use gem package manager to get them.
+
+· nokogiri
+· watir
+
+## Instalation
+
+```bash
+$ gem install pkg-query
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
After installing ruby for the first time (on an Arch based distro btw). I found out, with zero experience with ruby so correct me if I did something wrong, that those two ruby packages were needed (nokogiri and watir). In reality both packages pulled like 6-8 more of packages as dependencies. So I just added the instructions to install them in the README file.